### PR TITLE
chore: reset.css 폰트 크기 설정 추가

### DIFF
--- a/src/shared/styles/reset.css.ts
+++ b/src/shared/styles/reset.css.ts
@@ -1,62 +1,63 @@
 // styles/global.css.ts
-import { globalStyle } from "@vanilla-extract/css";
-import * as layers from "./layer.css";
-import { vars } from "./tokens.css";
+import { globalStyle } from '@vanilla-extract/css';
+import * as layers from './layer.css';
+import { vars } from './tokens.css';
 
 // 1. Reset
 globalStyle(
-  "*:where(:not(html, iframe, canvas, img, svg, video, audio):not(svg *, symbol *))",
+  '*:where(:not(html, iframe, canvas, img, svg, video, audio):not(svg *, symbol *))',
   {
-    "@layer": {
+    '@layer': {
       [layers.reset]: {
-        all: "unset",
-        display: "revert",
+        all: 'unset',
+        display: 'revert',
       },
     },
   }
 );
 
-globalStyle("*, *::before, *::after", {
-  "@layer": {
+globalStyle('*, *::before, *::after', {
+  '@layer': {
     [layers.reset]: {
-      boxSizing: "border-box",
+      boxSizing: 'border-box',
     },
   },
 });
 
-globalStyle("html", {
-  "@layer": {
+globalStyle('html', {
+  '@layer': {
     [layers.reset]: {
-      MozTextSizeAdjust: "none",
-      WebkitTextSizeAdjust: "none",
-      textSizeAdjust: "none",
+      fontSize: '62.5%',
+      MozTextSizeAdjust: 'none',
+      WebkitTextSizeAdjust: 'none',
+      textSizeAdjust: 'none',
     },
   },
 });
 
-globalStyle("ol, ul, menu, summary", {
-  "@layer": {
+globalStyle('ol, ul, menu, summary', {
+  '@layer': {
     [layers.reset]: {
-      listStyle: "none",
+      listStyle: 'none',
     },
   },
 });
 
 globalStyle(':where([contenteditable]:not([contenteditable="false"]))', {
   // @ts-expect-error: -webkit-line-break is a non-standard property
-  "@layer": {
+  '@layer': {
     [layers.reset]: {
-      MozUserModify: "read-write",
-      WebkitUserModify: "read-write",
-      overflowWrap: "break-word",
-      WebkitLineBreak: "after-white-space",
-      WebkitUserSelect: "auto",
+      MozUserModify: 'read-write',
+      WebkitUserModify: 'read-write',
+      overflowWrap: 'break-word',
+      WebkitLineBreak: 'after-white-space',
+      WebkitUserSelect: 'auto',
     },
   },
 });
 
-globalStyle("body", {
-  "@layer": {
+globalStyle('body', {
+  '@layer': {
     [layers.reset]: {
       margin: 0,
       backgroundColor: vars.color.white,
@@ -65,13 +66,13 @@ globalStyle("body", {
   },
 });
 
-globalStyle("#root", {
-  "@layer": {
+globalStyle('#root', {
+  '@layer': {
     [layers.components]: {
-      maxWidth: "375px",
-      margin: "0 auto",
-      width: "100%",
-      minHeight: "100vh",
+      maxWidth: '375px',
+      margin: '0 auto',
+      width: '100%',
+      minHeight: '100vh',
       backgroundColor: vars.color.white,
     },
   },


### PR DESCRIPTION
## 📝 PR 내용 요약

- reset.css에 폰트 크기 관련한 설정이 누락되어서 추가했습니다. 

## ✅ 작업 상세

- 10px = 1rem 될 수 있도록 fontSize에 62.5% 적용했습니다. 

## #️⃣ 연관 이슈

- #7 


