### PR TITLE
feat: 날짜 선택 회차 카드 컴포넌트 구현 

### DIFF
--- a/src/pages/Main/MainPage.tsx
+++ b/src/pages/Main/MainPage.tsx
@@ -1,15 +1,20 @@
-import SeatBottomSheet from "@/shared/components/SeatBottomSheet/SeatBottomSheet";
+import DateReservationCard from "@/shared/components/DateReservationCard/DateReservationCard";
 import { h1 } from "./MainPage.css";
 
+const seatData = [
+  { grade: 'R석', seatCount: 48, price: 66000 },
+  { grade: 'S석', seatCount: 32, price: 55000 },
+];
+
 function MainPage() {
+
   return (
     <div>
       <h1 className={h1}>인터파크 티켓</h1>
-      <SeatBottomSheet
-        placeInfo="예스24아트원 2관"
-        dateTime="2025.04.29 / 19:30"
-        seatInfo="R석 1층 F열 17"
-        price={66000}
+      <DateReservationCard
+        performanceTime="오후 7:30"
+        authors="이형훈, 김이준, 홍금비, 박성현"
+        seatTypes={seatData}
       />
     </div>
   );

--- a/src/shared/components/DateReservationCard/DateReservationCard.css.ts
+++ b/src/shared/components/DateReservationCard/DateReservationCard.css.ts
@@ -1,0 +1,85 @@
+import { style } from '@vanilla-extract/css';
+import { vars } from '@/shared/styles/tokens.css';
+import { fontStyle } from '@/shared/styles/fontStyle';
+
+export const reservationCardWrapper = style({
+  display: 'flex',
+  flexDirection: 'column',
+  width: '33.9rem',
+  boxSizing: 'border-box',
+  backgroundColor: vars.color.blue10,
+  borderRadius: '0.6rem',
+});
+
+export const contentContainer = style({
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+  height: '6.7rem',
+  padding: '1.4rem 1.4rem',
+});
+
+export const performInfoContainer = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '0.6rem',
+});
+
+export const dateText = style({
+  color: vars.color.blue120,
+  ...fontStyle('b2_b_16'),
+});
+
+export const authorsText = style({
+  color: vars.color.gray60,
+  ...fontStyle('b14_me_12'),
+});
+
+export const line = style({
+  display: 'block',
+  height: '.1rem',
+  width: '33.8rem',
+  backgroundColor: vars.color.gray20,
+  border: 'none',
+});
+
+// 좌석 정보 
+export const seatInfoWrapper = style({
+  display: 'flex',
+  flexDirection: 'column',
+  height: '9.5rem',
+  padding: '1.4rem 1.4rem',
+  gap: '1rem',
+});
+
+export const seatHeader = style({
+  color: vars.color.gray80,
+  ...fontStyle('b8_sb_14'),
+});
+
+export const seatInfoContainer = style({
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+});
+
+export const gradeText = style({
+  color: vars.color.gray60,
+  ...fontStyle('b14_me_12'),
+});
+
+export const seatContentContainer = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '0.8rem'
+});
+
+export const seatCountText = style({
+  color: vars.color.blue90,
+  ...fontStyle('b14_me_12'),
+});
+
+export const priceText = style({
+  color: vars.color.gray90,
+  ...fontStyle('b8_sb_14'),
+});

--- a/src/shared/components/DateReservationCard/DateReservationCard.tsx
+++ b/src/shared/components/DateReservationCard/DateReservationCard.tsx
@@ -1,0 +1,51 @@
+import BookingButton from '../BookingButton/BookingButton';
+import * as styles from './DateReservationCard.css';
+
+interface SeatType {
+  grade: string;
+  seatCount: number;
+  price: number;
+}
+
+interface DateReservationCardProps {
+  performanceTime: string,
+  authors: string,
+  seatTypes: SeatType[];
+}
+
+const DateReservationCard = ({
+  performanceTime,
+  authors,
+  seatTypes,
+}:DateReservationCardProps) => {
+
+  return (
+    <div className={styles.reservationCardWrapper}>
+      <div className={styles.contentContainer}>
+        <div className={styles.performInfoContainer}>
+          <span className={styles.dateText}>{performanceTime}</span>
+          <span className={styles.authorsText}>{authors}</span>
+        </div>
+        <BookingButton type="button">예매하기</BookingButton>
+      </div>
+
+      <hr className={styles.line} />
+
+      <div className={styles.seatInfoWrapper}>
+        <p className={styles.seatHeader}>좌석정보</p>
+
+        {seatTypes.map(({ grade, seatCount, price }) => (
+          <div key={grade} className={styles.seatInfoContainer}>
+            <span className={styles.gradeText}>{grade}</span>
+            <div className={styles.seatContentContainer}>
+              <span className={styles.seatCountText}>{seatCount}석</span>
+              <span className={styles.priceText}>{price.toLocaleString()}원</span>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default DateReservationCard;


### PR DESCRIPTION
## 📝 PR 내용 요약

- 날짜 선택시 공연 회차를 선택하는 카드 컴포넌트를 구현했습니다. 

## ✅ 작업 상세

- api 명세서 보고 props, type 임시로 해뒀습니다!
- 목데이터로 다음과 같이 입력해서 테스트했습니다.
```tsx
const seatData = [
  { grade: 'R석', seatCount: 48, price: 66000 },
  { grade: 'S석', seatCount: 32, price: 55000 },
];
```
- 컴포넌트 사용시 다음과 같이 사용하면 될 것 같습니다 
```tsx
      <DateReservationCard
          performanceTime="오후 7:30"
          authors="이형훈, 김이준, 홍금비, 박성현"
          seatTypes={seatData}
      />
```

## #️⃣ 연관 이슈

> #43 

## 🖼️ 변경된 화면 (선택)

![image](https://github.com/user-attachments/assets/a77362a2-57e6-43cd-8408-7f40e6dd7abc)

## 💬 기타 논의 사항 (선택)

- 이슈/리뷰 요청/고민 중인 내용 등

## 💬 리뷰 요구사항 (선택)

- 리뷰 시 꼭 봐줬으면 하는 부분이 있다면 작성
